### PR TITLE
Feature/show all monsters

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -2,12 +2,14 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import Search from './Search'
 import Filter from './Filter'
+import ShowAllMonsters from './ShowAllMonsters'
 import './Header.css'
 
 const Header = () => {
     return (
         <header>Header
             <Search />
+            <ShowAllMonsters />
             <Filter />
             <Link to="/encounter">Encounter</Link>
             <Link to="/">Home</Link>

--- a/src/components/ShowAllMonsters.css
+++ b/src/components/ShowAllMonsters.css
@@ -1,0 +1,8 @@
+.show-all-btn {
+  border-radius: 10px;
+  border: 2px solid #ac9485;
+  height: 1.5rem;
+  box-sizing: content-box;
+  margin: 1%;
+  background-color: #b34ec3;
+}

--- a/src/components/ShowAllMonsters.js
+++ b/src/components/ShowAllMonsters.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { searchMonster } from '../actions/actions'
+import { connect } from 'react-redux'
+import './ShowAllMonsters.css'
+
+const ShowAllMonsters = () => {
+  const monsterList = this.props.monsters
+  return(
+    <button 
+      className="show-all-btn"
+      onClick={() => this.props.searchMonster(monsterList)}>
+      Show All
+    </button>
+  )
+}
+
+const mapStateToProps = (state) => ({
+  monsters: state.monsters.monsters,
+})
+
+export default connect(mapStateToProps, { searchMonster })(ShowAllMonsters);

--- a/src/components/ShowAllMonsters.js
+++ b/src/components/ShowAllMonsters.js
@@ -1,17 +1,19 @@
-import React from 'react'
+import React, { Component } from 'react'
 import { searchMonster } from '../actions/actions'
 import { connect } from 'react-redux'
 import './ShowAllMonsters.css'
 
-const ShowAllMonsters = () => {
-  const monsterList = this.props.monsters
-  return(
-    <button 
-      className="show-all-btn"
-      onClick={() => this.props.searchMonster(monsterList)}>
-      Show All
-    </button>
-  )
+class ShowAllMonsters extends Component {
+  render(){
+    const monsterList = this.props.monsters
+    return(
+      <button 
+        className="show-all-btn"
+        onClick={() => this.props.searchMonster(monsterList)}>
+        Show All
+      </button>
+    )
+  }
 }
 
 const mapStateToProps = (state) => ({


### PR DESCRIPTION
## Is this PR a fix/feature/test/other?
Feature

## What does this PR do?
This feature adds a component that allows the page to rerender with all monsters in the list.

## Where should the reviewer start?
All of ```ShowAllMonsters.js``` and its corresponding CSS file.

## How is this tested?
Run ```npm start``` and open application on ```localhost:3000```.
In the search bar, search for a monster.
After new list renders, click the 'show all' button and the full list should return.

## Applicable Tickets?
#19 
