### PR TITLE
Add conditional render to empty encounter page.

### DIFF
--- a/src/components/Encounter.js
+++ b/src/components/Encounter.js
@@ -7,9 +7,16 @@ import { removeFromEncounter } from '../actions/actions'
 
 class Encounter extends Component {
   render() {
-    const encounterMonster = this.props.encounter.map((monster, i) => {
+    if(!this.props.encounter.length) {
       return (
-        <div key={i} className="encounter-element">
+        <h2>
+          You have no monsters in your encounter.
+        </h2>
+      )
+    } else {  
+      const encounterMonster = this.props.encounter.map((monster, i) => {
+        return (
+          <div key={i} className="encounter-element">
           <Link to={{
             pathname: `/monster/${monster.monsterIndex}`,
             state: {url: monster.monsterUrl}
@@ -28,6 +35,7 @@ class Encounter extends Component {
       </div>
     )
   }
+}
 
 }
 


### PR DESCRIPTION
## Is this PR a fix/feature/test/other?
Fix
## What does this PR do?
Display message that you have no monsters in your encounter ... if you have no monsters in your encounter.
## Where should the reviewer start?
`Encounter.js` lines 10-15
## How is this tested?
If you have monsters in your encounter, they should show up. If you don't, you should see the message.
## Applicable Tickets?
#50 

![image](https://user-images.githubusercontent.com/13261139/109566591-520f7480-7aa1-11eb-9e50-b6e8941abaa0.png)
![image](https://user-images.githubusercontent.com/13261139/109566633-5e93cd00-7aa1-11eb-87bd-881c30ac30a7.png)
