### PR TITLE
Show number of monsters in the encounter, on the button.

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -50,7 +50,7 @@ export const searchMonster = (monsterList, monsterName) => dispatch => {
 }}
 
 export const addToEncounter = (monsterName, monsterIndex, monsterUrl, encounter) => dispatch => {
-  encounter.push({monsterName, monsterIndex, monsterUrl})
+  encounter = [...encounter, {monsterName, monsterIndex, monsterUrl}]
   dispatch({
     type: ADD_TO_ENCOUNTER,
     payload: encounter

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
+import { connect } from 'react-redux'
 import Search from './Search'
 import Filter from './Filter'
 import ShowAllMonsters from './ShowAllMonsters'
@@ -7,9 +8,18 @@ import './Header.css'
 import Ldragon from '../dragon.svg'
 import Rdragon from '../dragonR.svg'
 
-const Header = () => {
+
+class Header extends Component {
+  constructor() {
+    super()
+    this.state = {}
+  }
+
+  render() {
+    const encounterCounter = this.props.encounter.length
+
     return (
-        <header className="header">
+      <header className="header">
             <div className="title">
               <img className="dragon" src={ Ldragon } alt="a dragon"/>
               <Link to="/home" className="app-name"><h1>MONSTRONOMICON</h1></Link>
@@ -20,11 +30,16 @@ const Header = () => {
               <ShowAllMonsters />
               <Filter />
               <div className="nav-button">
-                <Link to="/encounter" className="encounter-button">Encounter</Link>
+                <Link to="/encounter" className="encounter-button">Encounter ({encounterCounter})</Link>
               </div>
             </div>
         </header>
     )
+  }
 }
 
-export default Header
+const mapStateToProps = (state) => ({
+  encounter: state.encounter.encounter
+})
+
+export default connect(mapStateToProps, {})(Header);

--- a/src/components/Monster.js
+++ b/src/components/Monster.js
@@ -22,6 +22,7 @@ class Monster extends Component {
             this.props.location.state.url,
             this.props.encounter
         )
+        // make the header re-render
     }
 
     render() {

--- a/src/components/Monster.js
+++ b/src/components/Monster.js
@@ -22,7 +22,6 @@ class Monster extends Component {
             this.props.location.state.url,
             this.props.encounter
         )
-        // make the header re-render
     }
 
     render() {


### PR DESCRIPTION
## Is this PR a fix/feature/test/other?
Feature
## What does this PR do?
Adds an encounter counter to the encounter button, counting how many monsters you have in your encounter. I changed the `addToEncounter` action to use the spread operator instead of `.push`, and `Header.js` is a class function now.
## Where should the reviewer start?
`actions.js` 53, `Header.js`
## How is this tested?
When you have x monsters in the encounter, the Encounter button should say "Encounter (x)".
## Applicable Tickets?
#50 

![image](https://user-images.githubusercontent.com/13261139/109568164-c4815400-7aa3-11eb-86e6-ebda3e5ade7e.png)
![image](https://user-images.githubusercontent.com/13261139/109568178-ca773500-7aa3-11eb-90ad-7afc08d5b04f.png)
