### PR TITLE
Add mobile touch event listener to search button.

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -16,8 +16,9 @@ class Search extends Component {
 
   handleChange(event) {
     const {value} = event.target
+    console.log(value)
     this.setState({
-      monsterName: value
+      monsterName: value.toLowerCase()
     })
   }
 

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -58,6 +58,7 @@ class Search extends Component {
             <button 
               className="search-btn"
               ref={node => (this.btn = node)}
+              onTouchStart={(event) => this.handleClick(event)}
               onClick={(event) => this.handleClick(event)}
             ><img className="dice" src={ dice } alt="a d20"/></button>
           </form>

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -27,6 +27,11 @@ class Search extends Component {
     this.clearInput()
   }
 
+    handleMobileClick(event) {
+    this.props.searchMonster(this.props.monsters, this.state.monsterName)
+    this.clearInput()
+  }
+
   checkEnter(event) {
     if (event.keyCode === 13) {
       event.preventDefault()
@@ -58,7 +63,7 @@ class Search extends Component {
             <button 
               className="search-btn"
               ref={node => (this.btn = node)}
-              onTouchStart={(event) => this.handleClick(event)}
+              onTouchStart={(event) => this.handleMobileClick(event)}
               onClick={(event) => this.handleClick(event)}
             ><img className="dice" src={ dice } alt="a d20"/></button>
           </form>

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -27,11 +27,6 @@ class Search extends Component {
     this.clearInput()
   }
 
-    handleMobileClick(event) {
-    this.props.searchMonster(this.props.monsters, this.state.monsterName)
-    this.clearInput()
-  }
-
   checkEnter(event) {
     if (event.keyCode === 13) {
       event.preventDefault()
@@ -63,7 +58,7 @@ class Search extends Component {
             <button 
               className="search-btn"
               ref={node => (this.btn = node)}
-              onTouchStart={(event) => this.handleMobileClick(event)}
+              onTouchStart={(event) => this.handleClick(event)}
               onClick={(event) => this.handleClick(event)}
             ><img className="dice" src={ dice } alt="a d20"/></button>
           </form>

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -27,13 +27,6 @@ class Search extends Component {
     this.clearInput()
   }
 
-  checkEnter(event) {
-    if (event.keyCode === 13) {
-      event.preventDefault()
-      this.btn.click()
-    }
-  }
-
   clearInput() {
     this.setState({
       monsterName: ""
@@ -53,12 +46,10 @@ class Search extends Component {
               className="search-input"
               value={this.state.monsterName}
               onChange={this.handleChange}
-              onKeyDown={(event) => this.checkEnter(event)}
             ></input>
             <button 
               className="search-btn"
               ref={node => (this.btn = node)}
-              onTouchStart={(event) => this.handleClick(event)}
               onClick={(event) => this.handleClick(event)}
             ><img className="dice" src={ dice } alt="a d20"/></button>
           </form>

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -16,7 +16,6 @@ class Search extends Component {
 
   handleChange(event) {
     const {value} = event.target
-    console.log(value)
     this.setState({
       monsterName: value.toLowerCase()
     })
@@ -35,7 +34,6 @@ class Search extends Component {
   }
   
   render(){  
-    // searches the displayed list of monsters by name
     return (
       <div className="nav-button">
         <div className="search-field1">
@@ -50,7 +48,6 @@ class Search extends Component {
             ></input>
             <button 
               className="search-btn"
-              ref={node => (this.btn = node)}
               onClick={(event) => this.handleClick(event)}
             ><img className="dice" src={ dice } alt="a d20"/></button>
           </form>


### PR DESCRIPTION
## Is this PR a fix/feature/test/other?
Fix
## What does this PR do?
Removes the 'check to see if the user pressed Enter' function. I don't think it was doing anything. I don't think we need a listener for mobile - I added the toLowerCase method instead.
## Where should the reviewer start?
`Search.js`
## How is this tested?
The search should still work.
## Applicable Tickets?
#63 